### PR TITLE
feat!(docker): fix build error and use unprivileged NGINX

### DIFF
--- a/.taskfiles/hugo/taskfile.yaml
+++ b/.taskfiles/hugo/taskfile.yaml
@@ -113,7 +113,8 @@ tasks:
       - task: _start
         # silent: true
     cmds:
-      - docker run --rm -p 8080:8080 ghcr.io/ahgraber/aimlbling-about:debug
+      - docker run --rm -p 80:8080 ghcr.io/ahgraber/aimlbling-about:debug
+      - echo "Access site at http://127.0.0.1"
       - echo "Run 'colima stop' to clean up!"
     preconditions:
       - {msg: "Docker not found", sh: "type docker"}

--- a/docs/containerize.md
+++ b/docs/containerize.md
@@ -20,7 +20,8 @@ docker build -t ghcr.io/ahgraber/aimlbling-about:debug -f ./docker/Dockerfile .
 Run image:
 
 ```sh
-docker run --rm -p  80:80 ghcr.io/ahgraber/aimlbling-about:debug
+docker run --rm -p 80:8080 ghcr.io/ahgraber/aimlbling-about:debug
+echo "Navigate to http://127.0.0.1"
 ```
 
 Stop colima:
@@ -50,7 +51,7 @@ Build and push image:
 docker buildx create --use
 docker buildx build \
   --push \
-  --platform  linux/amd64,linux/arm64 \
+  --platform linux/amd64,linux/arm64 \
   -t ghcr.io/ahgraber/aimlbling-about:debug \
   -f ./docker/Dockerfile \
   .

--- a/docs/containerize.md
+++ b/docs/containerize.md
@@ -14,13 +14,13 @@ Build the container image:
 
 ```sh
 # build image
-docker build -t ghcr.io/ahgraber/aimlbling-about:debug -f ./docker/Dockerfile .
+docker build -t ghcr.io/ahgraber/aimlbling-about:debug -f ./hugo/docker/Dockerfile .
 ```
 
 Run image:
 
 ```sh
-docker run --rm -p 80:8080 ghcr.io/ahgraber/aimlbling-about:debug
+docker run --rm -p 80:80 ghcr.io/ahgraber/aimlbling-about:debug
 echo "Navigate to http://127.0.0.1"
 ```
 
@@ -53,7 +53,7 @@ docker buildx build \
   --push \
   --platform linux/amd64,linux/arm64 \
   -t ghcr.io/ahgraber/aimlbling-about:debug \
-  -f ./docker/Dockerfile \
+  -f ./hugo/docker/Dockerfile \
   .
 ```
 

--- a/hugo/docker/Dockerfile
+++ b/hugo/docker/Dockerfile
@@ -1,5 +1,5 @@
 # https://sko.ai/blog/how-to-actually-build-hugo-containers/
-FROM --platform=$BUILDPLATFORM docker.io/library/alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c as build
+FROM --platform=$BUILDPLATFORM docker.io/library/alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS build
 RUN apk add --no-cache \
     git \
     hugo \

--- a/hugo/docker/Dockerfile
+++ b/hugo/docker/Dockerfile
@@ -1,24 +1,25 @@
 # https://sko.ai/blog/how-to-actually-build-hugo-containers/
 FROM --platform=$BUILDPLATFORM docker.io/library/alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c as build
-RUN  apk add --no-cache \
-      git \
-      hugo \
-      tzdata \
-  && apk add --no-cache dart-sass --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing/
+RUN apk add --no-cache \
+    git \
+    hugo \
+    tzdata \
+    curl \
+    unzip
+
+# Set Dart Sass version
+ENV DART_SASS_VERSION=1.86.3
+
+# Download and install Dart Sass binary
+RUN curl -sSL https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64-musl.tar.gz \
+    | tar -xz -C /usr/local/bin --strip-components=1
+
 WORKDIR /src
 COPY . .
 RUN --mount=type=cache,target=/tmp/hugo_cache \
     hugo --minify -s ./hugo
 
-FROM docker.io/library/nginx:1.27@sha256:5ed8fcc66f4ed123c1b2560ed708dc148755b6e4cbd8b943fab094f2c6bfa91e
-# implement changes required to run NGINX as an less-privileged user
-RUN  sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
-  && sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" /etc/nginx/nginx.conf \
-  # nginx user must own the cache and etc directory to write cache and tweak the nginx config
-  && chown -R 101:0 /var/cache/nginx \
-  && chmod -R g+w /var/cache/nginx \
-  && chown -R 101:0 /etc/nginx \
-  && chmod -R g+w /etc/nginx
+FROM docker.io/nginxinc/nginx-unprivileged:1.27
 
 COPY --chown=nginx:nginx --from=build /src/hugo/public /site
 COPY --chown=nginx:nginx ./hugo/docker/default.conf /etc/nginx/conf.d/

--- a/hugo/docker/default.conf
+++ b/hugo/docker/default.conf
@@ -1,7 +1,7 @@
 # ref: https://github.com/hugomods/docker/blob/main/docker/nginx/conf.d/default.conf
 server {
-    listen 80;
-    listen [::]:80;
+    listen 8080;
+    listen [::]:8080;
     server_name localhost;
 
     gzip on;
@@ -28,6 +28,7 @@ server {
     }
 
     # Redirect to HTTPS if the original request to the reverse proxy was HTTP
+    # NOTE: This will prevent local testing due to the lack https support in docker
     if ($forwarded_proto != 'https') {
         return 301 https://$host$request_uri;
     }

--- a/hugo/docker/default.conf
+++ b/hugo/docker/default.conf
@@ -1,7 +1,7 @@
 # ref: https://github.com/hugomods/docker/blob/main/docker/nginx/conf.d/default.conf
 server {
-    listen 8080;
-    listen [::]:8080;
+    listen 80;
+    listen [::]:80;
     server_name localhost;
 
     gzip on;


### PR DESCRIPTION
- feat!(docker): fix build error and use unprivileged NGINX

  - Breaking: use unprivileged NGINX, which listens on 8080.
  - Fix docker build error due to dart-sass requirements
  - Documentation