### PR TITLE
Add AI bots and update sitemap in robots.txt

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -9,7 +9,7 @@ proseWrap: "preserve" # preserve linebreaks in markdown
 plugins:
   # for global plugins, use full path; dots get to $HOME
   - "../../.nix-profile/lib/node_modules/prettier-plugin-go-template/lib/index.js"
-  - "../../.nix-profile/lib/node_modules/prettier-plugin-toml/lib/index.js"
+  # - "../../.nix-profile/lib/node_modules/prettier-plugin-toml/lib/index.js"
 overrides:
   - files: ["*.html", "*.css"]
     options:

--- a/hugo/layouts/treadmill/list.html
+++ b/hugo/layouts/treadmill/list.html
@@ -12,7 +12,7 @@
 
           {{ if .Pages }}
             <ul>
-              {{ range .Pages.ByDate }}
+              {{ range .Pages.ByDate.Reverse }}
                 <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
               {{ end }}
             </ul>

--- a/hugo/static/robots.txt
+++ b/hugo/static/robots.txt
@@ -1,8 +1,16 @@
-# disallow
+# Robots.txt
+## Refs:
+## - https://nytimes.com/robots.txt
+## - https://darkvisitors.com/agents
+
+## Disallow Rules
 User-agent: Amazonbot
 Disallow: /
 
 User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Applebot-Extended
 Disallow: /
 
 User-agent: AwarioRssBot
@@ -15,9 +23,6 @@ Disallow: /
 User-agent: CCBot
 Disallow: /
 
-User-agent: ChatGPT-User
-Disallow: /
-
 User-agent: ClaudeBot
 Disallow: /
 
@@ -27,10 +32,22 @@ Disallow: /
 User-agent: cohere-ai
 Disallow: /
 
+User-agent: cohere-training-data-crawler
+Disallow: /
+
 User-agent: DataForSeoBot
 Disallow: /
 
+User-agent: Diffbot
+Disallow: /
+
+User-agent: DuckAssistBot
+Disallow: /
+
 User-agent: FacebookBot
+Disallow: /
+
+User-agent: Google-CloudVertexBot
 Disallow: /
 
 User-agent: Google-Extended
@@ -39,13 +56,33 @@ Disallow: /
 User-agent: GPTBot
 Disallow: /
 
+User-agent: Meta-ExternalAgent
+User-agent: meta-externalagent
+Disallow: /
+
+User-agent: Meta-ExternalFetcher
+User-agent: meta-externalfetcher
+Disallow: /
+
+User-agent: MyCentralAIScraperBot
+Disallow: /
+
 User-agent: magpie-crawler
+Disallow: /
+
+User-agent: OAI-SearchBot
 Disallow: /
 
 User-agent: omgili
 Disallow: /
 
 User-agent: omgilibot
+Disallow: /
+
+User-agent: PanguBot
+Disallow: /
+
+User-agent: PetalBot
 Disallow: /
 
 User-agent: peer39_crawler
@@ -56,8 +93,21 @@ User-agent: PerplexityBot
 Disallow: /
 
 User-agent: SemrushBot
+User-agent: SemrushBot-BA
+User-agent: SemrushBot-CT
+User-agent: SemrushBot-OCOB
+User-agent: SemrushBot-SI
+User-agent: SemrushBot-SWA
+Disallow: /
+
+User-agent: YouBot
 Disallow: /
 
 # Default allow all others
 User-agent: *
 Allow: /
+Crawl-delay: 10
+
+## Sitemaps
+
+Sitemap: https://aimlbling-about.ninerealmlabs.com/sitemap.xml


### PR DESCRIPTION
- implement AI bot entries in the robots.txt file, and include a sitemap reference in the robots.txt for better search engine indexing
- modify the treadmill sorting to display recent entries first.
- remove deprecated prettier plugin