### PR TITLE
Update treadmill page to redirect to latest post and exclude from sitemap

### DIFF
--- a/hugo/content/treadmill/_index.md
+++ b/hugo/content/treadmill/_index.md
@@ -3,6 +3,8 @@ title: AI Treadmill
 description: Keeping up with AI feels like sprinting uphill on a maxed-out treadmill
 cascade:
   type: treadmill
+sitemap:
+  exclude: true
 ---
 
 > "Keeping up with AI feels like sprinting uphill on a maxed-out treadmill"

--- a/hugo/layouts/treadmill/list.html
+++ b/hugo/layouts/treadmill/list.html
@@ -1,27 +1,30 @@
 {{ define "main" }}
-  <div class="hx-mx-auto hx-flex {{ partial "utils/page-width" . }}">
-    {{ partial "sidebar.html" (dict "context" .) }}
-    {{ partial "toc.html" . }}
-    <article
-      class="hx-w-full hx-break-words hx-flex hx-min-h-[calc(100vh-var(--navbar-height))] hx-min-w-0 hx-justify-center hx-pb-8 hx-pr-[calc(env(safe-area-inset-right)-1.5rem)]">
-      <main class="hx-w-full hx-min-w-0 hx-max-w-6xl hx-px-6 hx-pt-4 md:hx-px-12">
-        {{ partial "breadcrumb.html" . }}
-        <div class="content">
-          {{ if .Title }}<h1>{{ .Title }}</h1>{{ end }}
-          {{ .Content }}
-
-          {{ if .Pages }}
-            <ul>
-              {{ range .Pages.ByDate.Reverse }}
-                <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
-              {{ end }}
-            </ul>
-          {{ end }}
-        </div>
-        {{ partial "components/last-updated.html" . }}
-        {{ partial "components/pager.html" . }}
-        {{ partial "components/comments.html" . }}
-      </main>
-    </article>
-  </div>
+  {{ with (first 1 .Pages.ByDate.Reverse) }}
+    {{ range . }}
+      <meta http-equiv="refresh" content="0; url={{ .RelPermalink }}" />
+      <script type="text/javascript">
+        window.location.href = "{{ .RelPermalink }}"
+      </script>
+      <p>Redirecting to the latest post... <a href="{{ .RelPermalink }}">Click here if you are not redirected.</a></p>
+    {{ end }}
+  {{ else }}
+    <div class="hx-mx-auto hx-flex {{ partial "utils/page-width" . }}">
+      {{ partial "sidebar.html" (dict "context" .) }}
+      {{ partial "toc.html" . }}
+      <article
+        class="hx-w-full hx-break-words hx-flex hx-min-h-[calc(100vh-var(--navbar-height))] hx-min-w-0 hx-justify-center hx-pb-8 hx-pr-[calc(env(safe-area-inset-right)-1.5rem)]">
+        <main class="hx-w-full hx-min-w-0 hx-max-w-6xl hx-px-6 hx-pt-4 md:hx-px-12">
+          {{ partial "breadcrumb.html" . }}
+          <div class="content">
+            {{ if .Title }}<h1>{{ .Title }}</h1>{{ end }}
+            {{ .Content }}
+            <p>No posts found in this section.</p>
+          </div>
+          {{ partial "components/last-updated.html" . }}
+          {{ partial "components/pager.html" . }}
+          {{ partial "components/comments.html" . }}
+        </main>
+      </article>
+    </div>
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
Redirect the treadmill 'list' page to the most recent post and exclude the treadmill index from the sitemap as it serves only as a redirect.